### PR TITLE
Replace open/fstat/close with stat

### DIFF
--- a/lib/disk_store/eviction_strategies/lru.rb
+++ b/lib/disk_store/eviction_strategies/lru.rb
@@ -5,11 +5,8 @@ class DiskStore
         # Collect and sort files based on last access time
         sorted_files = files
           .map { |file|
-            data = nil
-            File.new(file, 'rb').tap { |fd|
-              data = { path: file, last_fetch: fd.atime, size: fd.size }
-            }.close
-            data
+            st = File.stat(file)
+            { path: file, last_fetch: st.atime, size: st.size }
           }
           .sort { |a, b| a[:last_fetch] <=> b[:last_fetch] } # Oldest first
 


### PR DESCRIPTION
Reduce syscalls by only calling `stat` for each filename instead of `open`, `fstat`, and `close`.
