### PR TITLE
Replace map+inject with inject

### DIFF
--- a/lib/disk_store/reaper.rb
+++ b/lib/disk_store/reaper.rb
@@ -96,7 +96,7 @@ class DiskStore
     end
 
     def current_cache_size
-      files.map { |file| File.size(file) }.inject { |sum, size| sum + size } || 0
+      files.inject(0) { |sum, file| sum + File.size(file) }
     end
 
     def maximum_cache_size


### PR DESCRIPTION
Use `inject` alone instead of `map` then `inject` to avoid creating an extra array.
