### PR TITLE
Move require 'open-uri' from DiskStore to the spec that uses it

### DIFF
--- a/lib/disk_store.rb
+++ b/lib/disk_store.rb
@@ -1,4 +1,3 @@
-require 'open-uri'
 require 'disk_store/reaper'
 
 class DiskStore

--- a/spec/disk_store_spec.rb
+++ b/spec/disk_store_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'open-uri'
 
 describe DiskStore do
   let(:cache) { DiskStore.new @tmpdir }


### PR DESCRIPTION
`open-uri` is not used by `DiskStore` itself, it is only used by one of the spec files.  Move the `require` to that spec file so `open-uri` is not loaded in production.
