### PR TITLE
Remove use of open-uri and dependency on vcr

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,32 +7,20 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.3.5)
-    crack (0.4.1)
-      safe_yaml (~> 0.9.0)
     diff-lcs (1.2.5)
-    multi_json (1.8.4)
-    rake (10.3.1)
+    rake (10.3.2)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.7)
+    rspec-core (2.14.8)
     rspec-expectations (2.14.5)
       diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.5)
-    safe_yaml (0.9.7)
-    vcr (2.8.0)
-    webmock (1.13.0)
-      addressable (>= 2.2.7)
-      crack (>= 0.3.2)
+    rspec-mocks (2.14.6)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   disk_store!
-  multi_json
   rspec
-  vcr
-  webmock

--- a/disk_store.gemspec
+++ b/disk_store.gemspec
@@ -22,8 +22,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rake"
 
   gem.test_files = Dir.glob("spec/**/*")
-  gem.add_development_dependency "multi_json"
   gem.add_development_dependency "rspec"
-  gem.add_development_dependency "vcr"
-  gem.add_development_dependency "webmock"
 end

--- a/spec/disk_store_spec.rb
+++ b/spec/disk_store_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe DiskStore do
   let(:cache) { DiskStore.new @tmpdir }
-  let(:file_contents) { "Hello, Doge" }
+  let(:file_contents) { SecureRandom.random_bytes(8192) }
   let(:file) { Tempfile.new("My Temp File.psd") }
   let(:key) { "doge" }
 
@@ -14,6 +14,7 @@ describe DiskStore do
   end
 
   before(:each) do
+    file.binmode
     file.write file_contents
     file.flush
   end
@@ -44,7 +45,7 @@ describe DiskStore do
       }.to change{ Dir[File.join(@tmpdir, "**/*")].size }.by(3)
 
       file_path = Dir[File.join(@tmpdir, "**/*")].last
-      expect(File.read(file_path)).to eq file_contents
+      expect(File.binread(file_path)).to eq file_contents
     end
   end
 
@@ -64,21 +65,6 @@ describe DiskStore do
       expect(cache.exist?(key)).to be_true
       cache.delete(key)
       expect(cache.exist?(key)).to be_false
-    end
-  end
-
-  context "web resources", :vcr do
-    let(:url) { "http://media.giphy.com/media/KXD1pSzGb3Khi/giphy.gif" }
-    let(:key) { "lolololol" }
-
-    it "should cache the result of a web resource in a file" do
-      expect(cache.exist?(key)).to be_false
-
-      cache.fetch(key) do
-        open(url)
-      end
-
-      expect(cache.read(key).read).to eq open(url).read
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,32 +1,12 @@
 require File.expand_path './lib/disk_store'
 require 'rspec'
+require 'securerandom'
 require 'tempfile'
 require 'tmpdir'
-require 'vcr'
-
-VCR.configure do |c|
-  c.configure_rspec_metadata!
-
-  c.default_cassette_options = {
-    serialize_with:              :json,
-    preserve_exact_body_bytes:   true,
-    decode_compressed_response:  true,
-    match_requests_on:          [:method]
-  }
-
-  c.cassette_library_dir = 'spec/cassettes'
-  c.hook_into :webmock
-  c.ignore_localhost = true
-end
 
 RSpec.configure do |config|
   config.color_enabled = true
   config.tty = true
 
   config.treat_symbols_as_metadata_keys_with_true_values = true
-
-  config.around(:each, :vcr) do |example|
-    name = example.metadata[:full_description].gsub(/\//, "_").split(/\s+/, 2).join("/").gsub(/[^\w\/]+/, "_").downcase
-    VCR.use_cassette(name) { example.call }
-  end
 end


### PR DESCRIPTION
#4 moved the `require 'open-uri'` from DiskStore into the specs so `open-uri` would not be loaded in production.  It would be better to remove the use of `open-uri` entirely, and this has a nice side effect of removing a number of development dependencies.

Only one spec uses `open-uri`, and it does so with this URL:

```
$ irb
2.0.0-p353 :001 > require 'open-uri'
=> true 
2.0.0-p353 :002 > open("http://media.giphy.com/media/KXD1pSzGb3Khi/giphy.gif")
=> #<Tempfile:/var/folders/86/_2n9z60n7f7d9r3x11f4b3340000gn/T/open-uri20140526-6669-41ytgw> 
```

The result is a `Tempfile` with binary data.  

The other specs already use a `Tempfile` but do not test binary data.  This change removes the spec depending on `open-uri` and changes the others to use binary data.  
