### PR TITLE
Return Ruby 1.9.3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
 rvm:
+  - 1.9.3
   - 2.0.0
   - 2.1.0

--- a/disk_store.gemspec
+++ b/disk_store.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{Cache fiels the smart way.}
   gem.homepage      = "http://cosmos.layervault.com/cache.html"
   gem.license       = 'MIT'
-  gem.required_ruby_version = ">= 2.0.0"
+  gem.required_ruby_version = ">= 1.9.3"
 
   gem.files         = `git ls-files`.split($/).delete_if { |f| f.include?('examples/') }
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }

--- a/lib/disk_store/eviction_strategies/none.rb
+++ b/lib/disk_store/eviction_strategies/none.rb
@@ -1,0 +1,13 @@
+class DiskStore
+  class Reaper
+    module None
+      def files_to_evict
+        []
+      end
+
+      def directories_to_evict
+        []
+      end
+    end
+  end
+end

--- a/lib/disk_store/reaper.rb
+++ b/lib/disk_store/reaper.rb
@@ -33,8 +33,8 @@ class DiskStore
     end
 
     def set_eviction_strategy(strategy)
-      return if strategy.nil?
-      self.class.send :prepend, DiskStore::Reaper.const_get(strategy)
+      strategy ||= :None
+      self.class.send :include, DiskStore::Reaper.const_get(strategy)
     end
 
     def start!
@@ -54,14 +54,6 @@ class DiskStore
 
     def needs_eviction?
       current_cache_size > maximum_cache_size
-    end
-
-    def files_to_evict
-      []
-    end
-
-    def directories_to_evict
-      []
     end
 
     def wait_for_next


### PR DESCRIPTION
I'm using jRuby and wondering why 1.9.3 support was removed.
